### PR TITLE
[Middlewares] Add `iri` middleware by default

### DIFF
--- a/lib/middlewares/default.js
+++ b/lib/middlewares/default.js
@@ -5,6 +5,7 @@ import healthMiddleware from '../../middlewares/health.js'
 import errorsMiddleware from '../../middlewares/errors.js'
 import notFoundMiddleware from '../../middlewares/notFound.js'
 import staticMiddleware from '../../middlewares/static.js'
+import iriMiddleware from '../../middlewares/iri.js'
 
 const currentDir = dirname(fileURLToPath(import.meta.url))
 
@@ -32,9 +33,15 @@ const templateStaticFiles = {
   }
 }
 
+const iri = {
+  module: iriMiddleware,
+  order: 0
+}
+
 export default {
   health,
   errors,
   notFound,
-  templateStaticFiles
+  templateStaticFiles,
+  iri
 }

--- a/lib/middlewares/standardize.js
+++ b/lib/middlewares/standardize.js
@@ -33,7 +33,7 @@ const standardize = (middleware) => {
 
   // make sure order is defined
   if (m.order === undefined) {
-    m.order = 0
+    m.order = 100
   }
 
   // make sure paths is defined and is an array

--- a/middlewares/iri.js
+++ b/middlewares/iri.js
@@ -1,0 +1,66 @@
+import path from 'path'
+
+const iri = (req, basePath) => {
+  let host = req.get('host')
+  let port = ''
+  let protocol = req.protocol
+  const originalUrl = new URL(`${protocol}://${host}${req.originalUrl}`)
+  let { pathname } = originalUrl
+
+  if (protocol === 'http' && req.socket.ssl) {
+    protocol = 'https'
+  }
+
+  if (basePath) {
+    pathname = path.join(basePath, pathname)
+  }
+
+  const headers = req.headers
+  host = headers.host
+
+  // use proxy header fields?
+  if (req.app && req.app.get('trust proxy')) {
+    if ('x-forwarded-proto' in headers) {
+      protocol = headers['x-forwarded-proto']
+    }
+
+    if ('x-forwarded-host' in headers) {
+      host = headers['x-forwarded-host']
+    }
+  }
+
+  if (!host) {
+    const address = req.socket.address()
+    host = `${address.address}:${address.port}`
+  }
+
+  const hostSplit = host.split(':')
+  if (hostSplit.length > 1) {
+    host = hostSplit[0]
+    port = parseInt(hostSplit[1])
+  }
+
+  // ignore port if default http(s) port
+  if ([80, 443].includes(port)) {
+    port = ''
+  }
+
+  // add ':' before port number
+  if (port && port !== '') {
+    port = `:${port}`
+  }
+
+  return `${protocol}://${host}${port}${pathname}`
+}
+
+const factory = (trifid) => {
+  const { config } = trifid
+  const { basePath } = config
+
+  return (req, _res, next) => {
+    req.iri = decodeURI(iri(req, basePath))
+    next()
+  }
+}
+
+export default factory

--- a/middlewares/iri.js
+++ b/middlewares/iri.js
@@ -54,11 +54,12 @@ const iri = (req, basePath) => {
 }
 
 const factory = (trifid) => {
-  const { config } = trifid
+  const { config, logger } = trifid
   const { basePath } = config
 
   return (req, _res, next) => {
     req.iri = decodeURI(iri(req, basePath))
+    logger.debug(`value for req.iri: ${req.iri}`)
     next()
   }
 }


### PR DESCRIPTION
This will allow each middlewares to access the value of the IRI by using `req.iri`.
This middleware is included by default and has an order `0`, which means it should be included first.
The default value for `order` changed from `0` to `100` to avoid any issue with this.