### PR TITLE
feat: include locals middleware in default

### DIFF
--- a/lib/middlewares/default.js
+++ b/lib/middlewares/default.js
@@ -6,6 +6,7 @@ import errorsMiddleware from '../../middlewares/errors.js'
 import notFoundMiddleware from '../../middlewares/notFound.js'
 import staticMiddleware from '../../middlewares/static.js'
 import iriMiddleware from '../../middlewares/iri.js'
+import localsMiddleware from '../../middlewares/locals.js'
 
 const currentDir = dirname(fileURLToPath(import.meta.url))
 
@@ -38,10 +39,16 @@ const iri = {
   order: 0
 }
 
+const locals = {
+  module: localsMiddleware,
+  order: 1
+}
+
 export default {
   health,
   errors,
   notFound,
   templateStaticFiles,
-  iri
+  iri,
+  locals
 }

--- a/middlewares/locals.js
+++ b/middlewares/locals.js
@@ -1,0 +1,25 @@
+import absoluteUrl from 'absolute-url'
+import url from 'url'
+
+function factory (trifid) {
+
+  return (req, res, next) => {
+
+    absoluteUrl.attach(req)
+
+    // requested resource
+    res.locals.iri = req.iri
+
+    // requested resource parsed into URL object
+    res.locals.url = new url.URL(res.locals.iri)
+
+    // dummy translation
+    res.locals.t = res.locals.t || (x => {
+      return x.substring(x.indexOf(':') + 1)
+    })
+    next()
+  }
+
+}
+
+export default factory

--- a/middlewares/locals.js
+++ b/middlewares/locals.js
@@ -1,0 +1,22 @@
+import absoluteUrl from 'absolute-url'
+import url from 'url'
+
+function factory (trifid) {
+  return (req, res, next) => {
+    absoluteUrl.attach(req)
+
+    // requested resource
+    res.locals.iri = req.iri
+
+    // requested resource parsed into URL object
+    res.locals.url = new url.URL(res.locals.iri)
+
+    // dummy translation
+    res.locals.t = res.locals.t || (x => {
+      return x.substring(x.indexOf(':') + 1)
+    })
+    next()
+  }
+}
+
+export default factory

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "npm": ">=8"
   },
   "dependencies": {
+    "absolute-url": "^1.2.2",
     "ajv": "^8.11.0",
     "commander": "^9.3.0",
     "express": "^4.18.1",


### PR DESCRIPTION
This will allow each middleware to access the value of absoluteUrl
Has a default method `t` for translations