### PR TITLE
Create express middleware

### DIFF
--- a/lib/middlewares/loader.js
+++ b/lib/middlewares/loader.js
@@ -9,7 +9,7 @@ const resolvePath = (modulePath) => {
   }
 }
 
-const loader = async (modulePath) => {
+export const loader = async (modulePath) => {
   const middleware = await import(resolvePath(modulePath))
   return middleware.default
 }

--- a/middlewares/express.js
+++ b/middlewares/express.js
@@ -1,0 +1,24 @@
+import { loader } from '../lib/middlewares/loader.js'
+
+/**
+ * Import a plain Express middleware.
+ *
+ * Configuration fields:
+ *  - module (string, required): the name of the NPM module to load
+ *
+ * @param {*} trifid Trifid object containing the configuration, and other utility functions.
+ * @returns Express middleware.
+ */
+const factory = async (trifid) => {
+  const { config } = trifid
+  const { module } = config
+  if (!module) {
+    throw new Error("configuration is missing 'module' field")
+  }
+
+  const middleware = await loader(module)
+
+  return middleware()
+}
+
+export default factory

--- a/middlewares/express.js
+++ b/middlewares/express.js
@@ -5,20 +5,21 @@ import { loader } from '../lib/middlewares/loader.js'
  *
  * Configuration fields:
  *  - module (string, required): the name of the NPM module to load
+ *  - options (any, optional): some options to pass to the Express middleware
  *
  * @param {*} trifid Trifid object containing the configuration, and other utility functions.
  * @returns Express middleware.
  */
 const factory = async (trifid) => {
   const { config } = trifid
-  const { module } = config
+  const { module, options } = config
   if (!module) {
     throw new Error("configuration is missing 'module' field")
   }
 
   const middleware = await loader(module)
 
-  return middleware()
+  return middleware(options)
 }
 
 export default factory

--- a/middlewares/express.js
+++ b/middlewares/express.js
@@ -14,7 +14,7 @@ const factory = async (trifid) => {
   const { config } = trifid
   const { module, options } = config
   if (!module) {
-    throw new Error("configuration is missing 'module' field")
+    throw new Error("configuration requires 'module' field, specifying the Express middleware NPM module to load")
   }
 
   const middleware = await loader(module)


### PR DESCRIPTION
This PR adds a `express` middleware that can be used to load basic Express middlewares, like `helmet` or `morgan`.
Some basic options can be passed using the `options` option.