### PR TITLE
Inject local variables in the context for the view middleware

### DIFF
--- a/middlewares/view.js
+++ b/middlewares/view.js
@@ -28,7 +28,7 @@ const factory = async (trifid) => {
 
   return async (_req, res, _next) => {
     res.status(200)
-    res.send(await render(path, context, options))
+    res.send(await render(path, { ...context, locals: res.locals }, options))
   }
 }
 


### PR DESCRIPTION
This PR injects the `res.locals` variable into a `locals` variable that can be used in the views.

This is useful if we want to inject values coming from other middlewares.