### PR TITLE
Add cookie-parser in the core by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 import express from 'express'
 import pino from 'pino'
+import cookieParser from 'cookie-parser'
 
 import handler from './lib/config/handler.js'
 import { defaultHost, defaultLogLevel, defaultPort } from './lib/config/default.js'
@@ -68,6 +69,9 @@ const trifid = async (config, additionalMiddlewares = {}) => {
   const fullConfig = await handler(config)
   const server = express()
   server.disable('x-powered-by')
+
+  // add required middlewares
+  server.use(cookieParser())
 
   // configure Express server
   if (fullConfig?.server?.express) {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ajv": "^8.11.2",
     "camouflage-rewrite": "^1.4.0",
     "commander": "^9.4.1",
+    "cookie-parser": "^1.4.6",
     "express": "^4.18.2",
     "handlebars": "^4.7.7",
     "json5": "^2.2.1",


### PR DESCRIPTION
Adding the `cookie-parser` middleware by default in the stack will allow other plugins to directly manage cookies.