### PR TITLE
Have more open cors policy

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,10 @@ const trifid = async (config, additionalMiddlewares = {}) => {
   server.disable('x-powered-by')
 
   // add required middlewares
-  server.use(cors())
+  server.use(cors({
+    credentials: true,
+    origin: true
+  }))
   server.use(cookieParser())
 
   // configure Express server


### PR DESCRIPTION
Since the goal of Trifid is to be a dereferencing tool, having a more open CORS policy makes sense.